### PR TITLE
Fix bottom scroll bar on mobile

### DIFF
--- a/_sass/_responsive.scss
+++ b/_sass/_responsive.scss
@@ -6,6 +6,7 @@
 
     .wrapper {
         padding: $spacing-unit / 2;
+        margin: $spacing-unit / 4;
 
         section {
             .upper-row {


### PR DESCRIPTION
Adding small padding to fix bottom scroll bar appearing on mobile. This also keeps the card effect visible instead of sticking it to screen sides